### PR TITLE
calenderadd.ver

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:habitui/widget/Appnavigation.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:provider/provider.dart';
+import 'package:habitui/widget/calender_state.dart';
 
 void main() async {
   await initializeDateFormatting();
-  runApp(const MyApp());
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => CalendarState()),
+      ],
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:habitui/ui/checkbox.dart';
 import 'package:habitui/ui/liquid_indicator.dart';
+import 'package:habitui/widget/calender_state.dart';
+import 'package:provider/provider.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -12,13 +14,17 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   CalendarFormat _calendarFormat = CalendarFormat.week;
-  DateTime _focusedDay = DateTime.now();
-  DateTime? _selectedDate;
+  final DateTime _focusedDay = DateTime.now();
+
+  // 이 변수들은 달력의 년도와 월을 저장합니다.
+  int _currentYear = DateTime.now().year;
+  int _currentMonth = DateTime.now().month;
 
   @override
   void initState() {
     super.initState();
-    _selectedDate = _focusedDay;
+    _currentYear = _focusedDay.year;
+    _currentMonth = _focusedDay.month;
   }
 
   @override
@@ -31,33 +37,40 @@ class _HomeScreenState extends State<HomeScreen> {
             const SizedBox(
               height: 50,
             ),
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Icon(
+                    Icons.list_outlined,
+                    color: Colors.black,
+                  ),
+                  Text(
+                    '$_currentYear년 $_currentMonth월',
+                    style: const TextStyle(
+                        fontSize: 20, fontWeight: FontWeight.bold),
+                  ),
+                  Icon(
+                    Icons.settings,
+                    color: Colors.black,
+                  ),
+                ],
+              ),
+            ),
             TableCalendar(
               locale: 'ko_KR',
-              focusedDay: _focusedDay,
               calendarFormat: _calendarFormat,
+              headerVisible: false,
+              focusedDay: context.watch<CalendarState>().focusedDay,
               firstDay: DateTime.utc(2025, 01, 01),
               lastDay: DateTime.utc(2025, 12, 31),
-              headerStyle: const HeaderStyle(
-                formatButtonVisible: false,
-                titleCentered: true,
-                leftChevronVisible: true,
-                rightChevronVisible: true,
-                leftChevronIcon: Icon(
-                  Icons.list_outlined,
-                  color: Colors.black,
-                ),
-                rightChevronIcon: Icon(
-                  Icons.settings,
-                  color: Colors.black,
-                ),
-              ),
+              selectedDayPredicate: (day) =>
+                  isSameDay(context.watch<CalendarState>().selectedDate, day),
               onDaySelected: (selectedDay, focusedDay) {
-                if (!isSameDay(_selectedDate, selectedDay)) {
-                  setState(() {
-                    _selectedDate = selectedDay;
-                    _focusedDay = focusedDay;
-                  });
-                }
+                context.read<CalendarState>()
+                  ..setSelectedDate(selectedDay)
+                  ..setFocusedDay(focusedDay);
               },
               onFormatChanged: (format) {
                 if (_calendarFormat != format) {
@@ -67,11 +80,8 @@ class _HomeScreenState extends State<HomeScreen> {
                   });
                 }
               },
-              selectedDayPredicate: (day) {
-                return isSameDay(_selectedDate, day);
-              },
               onPageChanged: (focusedDay) {
-                _focusedDay = focusedDay;
+                context.read<CalendarState>().setFocusedDay(focusedDay);
               },
             ),
             const SizedBox(

--- a/lib/screen/status_screen.dart
+++ b/lib/screen/status_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:habitui/widget/SFTexpresstion.dart';
 import 'package:habitui/widget/customcircle.dart';
+import 'package:habitui/widget/calender_state.dart';
+import 'package:provider/provider.dart';
+import 'package:table_calendar/table_calendar.dart';
 
 class StatsScreen extends StatelessWidget {
   final int success;
@@ -52,7 +55,7 @@ class StatsScreen extends StatelessWidget {
               const SizedBox(height: 40),
               _buildChart(),
               const SizedBox(height: 40),
-              _buildCalendar(),
+              _buildCalendar(context),
             ],
           ),
         ),
@@ -203,35 +206,41 @@ class StatsScreen extends StatelessWidget {
     );
   }
 
-  // Calendar Section
-  Widget _buildCalendar() {
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 16),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: Colors.grey[900],
-        borderRadius: BorderRadius.circular(16),
-      ),
+  // Calendar Section homescreen에 있는거 펼쳐서 만들어 놓기
+
+  Widget _buildCalendar(BuildContext context) {
+    final currentYear = context.watch<CalendarState>().currentYear;
+    final currentMonth = context.watch<CalendarState>().currentMonth;
+
+    return Padding(
+      padding: const EdgeInsets.all(15),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('12월',
-              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
-          const SizedBox(height: 12),
-          GridView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 7,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
+          Padding(
+            padding: const EdgeInsets.only(bottom: 20),
+            child: Text(
+              '$currentYear년 $currentMonth월',
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
             ),
-            itemCount: 31,
-            itemBuilder: (context, index) {
-              return CircleAvatar(
-                backgroundColor: Colors.grey[800],
-                child: Text((index + 1).toString()),
-              );
+          ),
+          TableCalendar(
+            locale: 'ko_KR',
+            headerVisible: false,
+            focusedDay: context.watch<CalendarState>().focusedDay,
+            firstDay: DateTime.utc(2025, 01, 01),
+            lastDay: DateTime.utc(2025, 12, 31),
+            selectedDayPredicate: (day) =>
+                isSameDay(context.watch<CalendarState>().selectedDate, day),
+            onDaySelected: (selectedDay, focusedDay) {
+              context.read<CalendarState>()
+                ..setSelectedDate(selectedDay)
+                ..setFocusedDay(focusedDay);
+            },
+            onPageChanged: (focusedDay) {
+              context.read<CalendarState>().setFocusedDay(focusedDay);
             },
           ),
         ],

--- a/lib/widget/calender_state.dart
+++ b/lib/widget/calender_state.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class CalendarState with ChangeNotifier {
+  DateTime _focusedDay = DateTime.now();
+  DateTime _selectedDate = DateTime.now();
+
+  DateTime get focusedDay => _focusedDay;
+  DateTime get selectedDate => _selectedDate;
+
+  int get currentYear => _focusedDay.year; // 현재 연도
+  int get currentMonth => _focusedDay.month; // 현재 월
+
+  void setFocusedDay(DateTime day) {
+    _focusedDay = day;
+    notifyListeners();
+  }
+
+  void setSelectedDate(DateTime date) {
+    _selectedDate = date;
+    notifyListeners();
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -147,6 +147,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -155,6 +163,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   simple_gesture_detector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   intl: ^0.19.0
   liquid_progress_indicator_v2: ^0.5.0
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
HomeScreen 달력 윗부분 아이콘 및 head 부분 개선했고 
status_screen.dart 부분에 달력 추가했어.
두 달력이 서로 데이터를 공유해야 하기 때문에 provider를 이용했고 공통으로 관리하는 데이터는 widget에 calender_state.dart에 넣어둠
provider를 씀에 따라 main 약간 바뀌었으니 참고바람